### PR TITLE
Various edits

### DIFF
--- a/pkg/internal/parser.go
+++ b/pkg/internal/parser.go
@@ -54,6 +54,7 @@ type api struct {
 	PkgName      string
 	writer       io.Writer
 	IsNamespaced bool
+	HasStatus    bool
 
 	PkgNameUpperFirst string
 	VersionUpperFirst string
@@ -169,7 +170,7 @@ func (p *packages) WriteContent() error {
 	return templ.Execute(p.writer, p)
 }
 
-func NewAPI(root *loader.Package, info *markers.TypeInfo, version, group string, isNamespaced bool, w io.Writer) (*api, error) {
+func NewAPI(root *loader.Package, info *markers.TypeInfo, version, group string, isNamespaced, hasStatus bool, w io.Writer) (*api, error) {
 	typeInfo := root.TypesInfo.TypeOf(info.RawSpec.Name)
 	if typeInfo == types.Typ[types.Invalid] {
 		return nil, fmt.Errorf("unknown type: %s", info.Name)
@@ -181,6 +182,7 @@ func NewAPI(root *loader.Package, info *markers.TypeInfo, version, group string,
 		PkgName:      group,
 		writer:       w,
 		IsNamespaced: isNamespaced,
+		HasStatus:    hasStatus,
 	}
 
 	api.setCased()

--- a/pkg/internal/templates.go
+++ b/pkg/internal/templates.go
@@ -164,6 +164,15 @@ func (w *wrapped{{.Name}}) Update(ctx context.Context, {{.NameLowerFirst}} *{{.P
 	}
 	return w.delegate.Update(ctx, {{.NameLowerFirst}}, opts)
 }
+{{if .HasStatus}}
+func (w *wrapped{{.Name}}) UpdateStatus(ctx context.Context, {{.NameLowerFirst}} *{{.PkgName}}api{{.Version}}.{{.Name}}, opts metav1.UpdateOptions) (*{{.PkgName}}api{{.Version}}.{{.Name}}, error) {
+	ctx, err := w.checkCluster(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return w.delegate.UpdateStatus(ctx, {{.NameLowerFirst}}, opts)
+}
+{{end}}
 
 func (w *wrapped{{.Name}}) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	ctx, err := w.checkCluster(ctx)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,7 +17,10 @@ limitations under the License.
 package util
 
 import (
-	gobuild "go/build"
+	"fmt"
+	"golang.org/x/mod/modfile"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -25,14 +28,14 @@ import (
 // CurrentPackage returns the go package of the current directory, or "" if it cannot
 // be derived from the GOPATH.
 // This logic is taken from k8.io/code-generator, but has a change of letting user pass the
-// directory whose pacakge is to be found.
+// directory whose package is to be found.
 func CurrentPackage(dir string) string {
-	for _, root := range gobuild.Default.SrcDirs() {
-		if pkg, ok := hasSubdir(root, dir); ok {
-			return pkg
-		}
+	gomod, err := ioutil.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
-	return ""
+	return modfile.ModulePath(gomod)
 }
 
 func hasSubdir(root, dir string) (rel string, ok bool) {


### PR DESCRIPTION
Figure out the module from --input-dir's go.mod file.

Use the module as the dir for the loader context.

Add optional UpdateStatus generation.

Signed-off-by: Andy Goldstein <andy.goldstein@redhat.com>
